### PR TITLE
Add listthreads

### DIFF
--- a/src/libproc/proc_pid.rs
+++ b/src/libproc/proc_pid.rs
@@ -490,7 +490,7 @@ fn name_test_init_pid() {
 ///
 /// ```
 /// use std::io::Write;
-/// use libproc::libproc::proc_pid::{pidinfo, BSDInfo};
+/// use libproc::libproc::proc_pid::{listthreads, pidinfo, TaskInfo};
 ///
 /// fn listthreads_test() {
 ///     use std::process;

--- a/src/libproc/proc_pid.rs
+++ b/src/libproc/proc_pid.rs
@@ -507,11 +507,11 @@ fn name_test_init_pid() {
 ///     };
 /// }
 /// ```
-pub fn listthreads(pid: i32, threadnum: usize) -> Result<Vec<uint64_t>, String> {
-    let buffer_size = (mem::size_of::<uint64_t>() * threadnum) as i32;
-    let mut buffer = Vec::<uint64_t>::with_capacity(threadnum);
+pub fn listthreads(pid: i32, threadnum: i32) -> Result<Vec<uint64_t>, String> {
+    let buffer_size = mem::size_of::<uint64_t>() as i32 * threadnum;
+    let mut buffer = Vec::<uint64_t>::with_capacity(threadnum as usize);
     let buffer_ptr = unsafe {
-        buffer.set_len(threadnum);
+        buffer.set_len(threadnum as usize);
         buffer.as_mut_ptr() as *mut c_void
     };
 


### PR DESCRIPTION
I added `fn listthreads`.
This corresponds to `pidinfo::<ListThreads>()`, but this seems to be unavailable.
There is two reason. The first is that the return value size of `pidinfo::<ListThreads>()` is variable and `buffer_size` can't be calculated from `T: PIDInfo`.
The second is that the actual length of thread list is the return value of `proc_pidinfo` but `pidinfo` can't return it.
So I splited `listthreads()` from `pidinfo()`.