### PR TITLE
libproc-rs-43 Implement kmsgbuf() for linux

### DIFF
--- a/src/dmesg.rs
+++ b/src/dmesg.rs
@@ -16,8 +16,7 @@ extern crate libc;
 use crate::libproc::libproc::kmesg_buffer;
 
 fn main() {
-    match kmesg_buffer::kmsgbuf() {
-        Ok(message) => println!("{}", message),
-        Err(_) => return
+    if let Ok(message) = kmesg_buffer::kmsgbuf() {
+        println!("{}", message);
     }
 }

--- a/src/dmesg.rs
+++ b/src/dmesg.rs
@@ -13,19 +13,11 @@
 extern crate libproc;
 extern crate libc;
 
-use std::io::Write;
-use crate::libproc::libproc::proc_pid;
 use crate::libproc::libproc::kmesg_buffer;
 
 fn main() {
-    if proc_pid::am_root() {
-        loop {
-            match kmesg_buffer::kmsgbuf() {
-                Ok(message) => println!("{}", message),
-                Err(_) => return
-            }
-        }
-    } else {
-        writeln!(&mut std::io::stderr(), "Must be run as root").unwrap()
+    match kmesg_buffer::kmsgbuf() {
+        Ok(message) => println!("{}", message),
+        Err(_) => return
     }
 }

--- a/src/dmesg.rs
+++ b/src/dmesg.rs
@@ -3,11 +3,7 @@
 //! Usage
 //! =
 //!
-//! `> sudo dmesg`
-//!
-//! ---
-//!
-//! NOTE: This must be run as `root`
+//! `> dmesg`
 //!
 
 extern crate libproc;

--- a/src/dmesg.rs
+++ b/src/dmesg.rs
@@ -9,20 +9,14 @@
 //!
 //! NOTE: This must be run as `root`
 //!
-//! NOTE: For now this is only implemented for macos
-//!
 
 extern crate libproc;
 extern crate libc;
 
-#[cfg(target_os = "macos")]
 use std::io::Write;
-#[cfg(target_os = "macos")]
 use crate::libproc::libproc::proc_pid;
-#[cfg(target_os = "macos")]
 use crate::libproc::libproc::kmesg_buffer;
 
-#[cfg(target_os = "macos")]
 fn main() {
     if proc_pid::am_root() {
         match kmesg_buffer::kmsgbuf() {
@@ -32,9 +26,4 @@ fn main() {
     } else {
         writeln!(&mut std::io::stderr(), "Must be run as root").unwrap()
     }
-}
-
-#[cfg(target_os = "linux")]
-fn main() {
-    unimplemented!()
 }

--- a/src/dmesg.rs
+++ b/src/dmesg.rs
@@ -19,9 +19,11 @@ use crate::libproc::libproc::kmesg_buffer;
 
 fn main() {
     if proc_pid::am_root() {
-        match kmesg_buffer::kmsgbuf() {
-            Ok(message) => println!("{}", message),
-            Err(err) => writeln!(&mut std::io::stderr(), "Error: {}", err).unwrap()
+        loop {
+            match kmesg_buffer::kmsgbuf() {
+                Ok(message) => println!("{}", message),
+                Err(_) => return
+            }
         }
     } else {
         writeln!(&mut std::io::stderr(), "Must be run as root").unwrap()

--- a/src/libproc/helpers.rs
+++ b/src/libproc/helpers.rs
@@ -1,12 +1,11 @@
 use crate::errno::errno;
 
-/*
-    Helper function to get errno
-*/
-pub fn get_errno_with_message(ret: i32) -> String {
+/// Helper function to get errno and return a String with the passed in return_code, the error
+/// number and a possible message
+pub fn get_errno_with_message(return_code: i32) -> String {
     let e = errno();
     let code = e.0 as i32;
-    format!("return code = {}, errno = {}, message = '{}'", ret, code, e)
+    format!("return code = {}, errno = {}, message = '{}'", return_code, code, e)
 }
 
 /// Helper function that depending on the `ret` value:

--- a/src/libproc/kmesg_buffer.rs
+++ b/src/libproc/kmesg_buffer.rs
@@ -71,7 +71,7 @@ extern {
     fn proc_kmsgbuf(buffer: *mut MessageBuffer, buffersize: u32) -> c_int;
 }
 
-()/// Get the contents of the kernel message buffer
+/// Get the contents of the kernel message buffer
 ///
 /// Entries are in the format:
 /// faclev,seqnum,timestamp[optional, ...];message\n

--- a/src/libproc/kmesg_buffer.rs
+++ b/src/libproc/kmesg_buffer.rs
@@ -60,23 +60,6 @@ extern {
 }
 
 /// Get a message from the kernel message buffer - as used by dmesg
-/// extern crate libproc;
-/// extern crate libc;
-///
-/// use std::str;
-/// use std::io::Write;
-/// use crate::libproc::proc_pid::am_root;
-/// use libproc::libproc::kmesg_buffer;
-///
-/// fn main() {
-///     if am_root() {
-///         match kmesg_buffer::kmsgbuf() {
-///             Ok(message) => println!("{}", message),
-///             Err(err) => writeln!(&mut std::io::stderr(), "Error: {}", err).unwrap()
-///         }
-///     } else {
-///         writeln!(&mut std::io::stderr(), "Must be run as root").unwrap()
-///     }
 // See http://opensource.apple.com//source/system_cmds/system_cmds-336.6/dmesg.tproj/dmesg.c
 #[cfg(target_os = "macos")]
 pub fn kmsgbuf() -> Result<String, String> {
@@ -102,11 +85,8 @@ pub fn kmsgbuf() -> Result<String, String> {
         // The message buffer is circular; start at the read pointer, and go to the write pointer - 1.
         unsafe {
             let mut ch: u8;
-//                let newl : bool = false;
-//                let skip : bool = false;
             let mut p: *mut u8 = message_buffer.msg_bufc.offset(message_buffer.msg_bufx as isize);
             let ep: *mut u8 = message_buffer.msg_bufc.offset((message_buffer.msg_bufx - 1) as isize);
-//                let buf : [u8; 5];
 
             while p != ep {
                 // If at the end, then loop around to the start
@@ -116,40 +96,11 @@ pub fn kmsgbuf() -> Result<String, String> {
                 }
 
                 ch = *p;
-
-                /* Skip "\n<.*>" syslog sequences.
-                    if skip {
-                        if ch == '>' {
-                            newl = skip = false;
-                        }
-                        continue;
-                    }
-
-                    if newl && ch == '<' {
-                        skip = true;
-                        continue;
-                    }
-
-                    if ch == '\0' {
-                        continue;
-                    }
-
-                    newl = ch == '\n';
-
-//                    (void)vis(buf, ch, 0, 0);
-
-                    if buf[1] == 0 {
-                        output.append(buf[0]);
-                    } else {
-                        output.append("%s", buf);
-                    }
-                    */
-
                 output.push(ch);
                 p = p.offset(1);
             }
 
-            Ok(String::from_utf8(output).unwrap())
+            Ok(String::from_utf8(output).map_err(|_| "Could not convert to UTF-8")?)
         }
     }
 }
@@ -170,7 +121,6 @@ mod test {
 
     #[test]
     #[ignore]
-    // TODO implement ksmgbuf() on linux - https://github.com/andrewdavidmackenzie/libproc-rs/issues/43
     // TODO fix on macos: an error message is returned - https://github.com/andrewdavidmackenzie/libproc-rs/issues/39
     // Message buffer: MessageBuffer { magic: 0x3a657461, size: 1986947360, bufx: 1684630625}
     // thread 'libproc::kmesg_buffer::test::kmessagebuffer_test' panicked at 'The magic number 0x3a657461 is incorrect', src/libproc/kmesg_buffer.rs:194:33

--- a/src/libproc/kmesg_buffer.rs
+++ b/src/libproc/kmesg_buffer.rs
@@ -126,11 +126,8 @@ pub fn kmsgbuf() -> Result<String, String> {
     let kmsg_channel = spawn_kmsg_channel(file);
     let duration = time::Duration::from_millis(1);
     let mut buf = String::new();
-    loop {
-        match kmsg_channel.recv_timeout(duration) {
-            Ok(line) => buf.push_str(&line),
-            _ => break,
-        }
+    while let Ok(line) = kmsg_channel.recv_timeout(duration) {
+            buf.push_str(&line)
     }
 
     Ok(buf)

--- a/src/libproc/mod.rs
+++ b/src/libproc/mod.rs
@@ -8,8 +8,7 @@
 
 /// Get basic information about processes by PID
 pub mod proc_pid;
-/// Read from the Kernel Message buffer
-#[cfg(target_os = "macos")]
+/// Get messages from the kernel message buffer
 pub mod kmesg_buffer;
 /// Information about Work Queues - very MacOS specific
 pub mod work_queue_info;

--- a/src/libproc/proc_pid.rs
+++ b/src/libproc/proc_pid.rs
@@ -416,7 +416,7 @@ fn procfile_field(filename: &str, fieldname: &str) -> Result<String, String> {
     let lineheader = format!("{}{}", fieldname, SEPARATOR);
 
     // Open the file in read-only mode (ignoring errors).
-    let file = File::open(filename).unwrap_or_else(|_| panic!("Could not open /proc file '{}'", filename));
+    let file = File::open(filename).map_err(|_| format!("Could not open /proc file '{}'", filename))?;
     let reader = BufReader::new(file);
 
     // Read the file line by line using the lines() iterator from std::io::BufRead.


### PR DESCRIPTION
- make dmesg.rs cross-platform relying on the library implementing kmsgbuf() on linux
- kmesg_buffer - make all macos code only compile for mac and a skeleton function for linux
- mod.rs always include kmesg_buffer.rs