### PR TITLE
Release of 0.11.1 for publishing to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libproc"
-version = "0.11.0"
+version = "0.11.1"
 description = "A library to get information about running processes - for Mac OS X and Linux"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 repository = "https://github.com/andrewdavidmackenzie/libproc-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libproc"
-version = "0.10.1"
+version = "0.11.0"
 description = "A library to get information about running processes - for Mac OS X and Linux"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 repository = "https://github.com/andrewdavidmackenzie/libproc-rs"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,8 @@
-use std::env;
-use std::path::Path;
-
 #[cfg(target_os = "macos")]
 fn main() {
+    use std::env;
+    use std::path::Path;
+
     let bindings = bindgen::builder()
         .header_contents("libproc_rs.h", "#include <libproc.h>")
         .generate()

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,6 @@
+use std::env;
+use std::path::Path;
+
 #[cfg(target_os = "macos")]
 fn main() {
     let bindings = bindgen::builder()
@@ -5,8 +8,11 @@ fn main() {
         .generate()
         .expect("Failed to build libproc bindings");
 
+    let output_path = Path::new(&env::var("OUT_DIR").expect("OUT_DIR env var was not defined"))
+        .join("osx_libproc_bindings.rs");
+
     bindings
-        .write_to_file("src/osx_libproc_bindings.rs")
+        .write_to_file(output_path)
         .expect("Failed to write libproc bindings");
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ extern crate libc;
 extern crate errno;
 
 pub mod libproc;
+
 #[cfg(target_os = "macos")]
 #[allow(warnings, missing_docs)]
-mod osx_libproc_bindings;
+mod osx_libproc_bindings {
+include!(concat!(env!("OUT_DIR"), "/osx_libproc_bindings.rs"));
+}


### PR DESCRIPTION
In order to publish, must generate code in OUT_DIR. Bump the version number to 0.11.0