### PR TITLE
Update and minify dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ name = "dmesg"
 path = "src/dmesg.rs"
 
 [build-dependencies]
-bindgen = "0.53.1"
+bindgen = { version = "0.59.2", default-features = false, features = ["runtime"] }


### PR DESCRIPTION
Update bindgen to 0.59 (transitively updates `nom`, `cfg-if`, and others).
Minify requirements for bindgen (avoids transitive dependencies on `env_logger`, `clap`, and several other rather beefy crates).