### PR TITLE
Add new module, processes, to enumerate pids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libproc"
-version = "0.12.0"
+version = "0.13.0"
 description = "A library to get information about running processes - for Mac OS X and Linux"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 repository = "https://github.com/andrewdavidmackenzie/libproc-rs"
@@ -32,3 +32,7 @@ path = "src/dmesg.rs"
 
 [build-dependencies]
 bindgen = { version = "0.63.0", default-features = false, features = ["runtime"] }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+procfs = "0.14.1"
+tempfile = "3.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ extern crate libc;
 extern crate errno;
 
 pub mod libproc;
+/// List processes by type and / or by path
+pub mod processes;
 
 #[cfg(target_os = "macos")]
 #[allow(warnings, missing_docs)]

--- a/src/libproc/mod.rs
+++ b/src/libproc/mod.rs
@@ -32,3 +32,4 @@ pub mod file_info;
 pub mod net_info;
 
 mod helpers;
+pub(crate) mod sys;

--- a/src/libproc/sys/linux.rs
+++ b/src/libproc/sys/linux.rs
@@ -1,0 +1,359 @@
+use std::{fs, io, path};
+
+use crate::processes::ProcFilter;
+
+const FIRST_FIELD: isize = 2;
+
+enum ProcStatField {
+    // Commented out fields are skipped during parsing
+    // or not used in this module. Numbers are the
+    // offset from Status (2)
+    // PID = 0,
+    // Cmd = 1,
+    // Status = 2,
+    Ppid = 3 - FIRST_FIELD,
+    Pgrp = 4 - FIRST_FIELD,
+    // SID = 5,
+    TtyNr = 6 - FIRST_FIELD,
+    // rest ignored
+}
+
+/// Parse out a specific field from the stat file beloning to a path starting
+/// with /proc/<pid> Expects the indicated (0-based) field to be parsable as a
+/// u32 integer, and field must be > 2.  I/O errors are ignored, with the
+/// assumption that the process has gone away.
+fn proc_stat_field(proc_path: &path::Path, field: ProcStatField) -> Option<u32> {
+    use io::BufRead;
+
+    fs::File::open(proc_path.join("stat"))
+        .and_then(|f| {
+            // there should only be a single line, but best avoid reading more
+            let mut buffer = io::BufReader::new(f);
+            let mut line = String::new();
+            buffer.read_line(&mut line).map(|_| line)
+        })
+        .map_or(None, |line| {
+            line.rfind(')').and_then(|pos| {
+                // Skip past the PID and command; the command is wrapped in (..)
+                // and the closing parenthesis is the only such character in the
+                // line if scanned from the end.
+                line[pos + 2..]
+                    .split_ascii_whitespace()
+                    .nth(field as usize)
+                    .and_then(|v| v.parse().ok())
+            })
+        })
+}
+
+/// Get the owner UID of a given path, as an option. Errors are ignored, it is
+/// assumed the process went away.
+fn file_owner_uid(path: &path::Path) -> Option<u32> {
+    use std::os::unix::fs::MetadataExt;
+    fs::metadata(path).map(|md| md.uid()).ok()
+}
+
+/// Reads process information from /proc/<pid>/{,stat} to enumerate PIDs matching the filter
+pub fn listpids(proc_types: ProcFilter) -> io::Result<Vec<u32>> {
+    let mut pids = Vec::<u32>::new();
+
+    let proc_dir = fs::read_dir("/proc")?;
+
+    for entry in proc_dir {
+        let path = entry?.path();
+        let filename = path.file_name();
+        if let Some(name) = filename {
+            if let Some(n) = name.to_str() {
+                if let Ok(pid) = n.parse::<u32>() {
+                    let matches = match proc_types {
+                        ProcFilter::All => true,
+                        ProcFilter::ByProgramGroup { pgrpid } => {
+                            proc_stat_field(&path, ProcStatField::Pgrp) == Some(pgrpid)
+                        }
+                        ProcFilter::ByTTY { tty } => {
+                            proc_stat_field(&path, ProcStatField::TtyNr) == Some(tty)
+                        }
+                        ProcFilter::ByUID { uid } => file_owner_uid(&path) == Some(uid),
+                        ProcFilter::ByRealUID { ruid } => {
+                            file_owner_uid(&path.join("stat")) == Some(ruid)
+                        }
+                        ProcFilter::ByParentProcess { ppid } => {
+                            proc_stat_field(&path, ProcStatField::Ppid) == Some(ppid)
+                        }
+                    };
+                    if matches {
+                        pids.push(pid);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(pids)
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::{HashMap, HashSet};
+    use std::io::{Error, Write};
+
+    use procfs;
+    use tempfile;
+
+    use super::*;
+
+    #[test]
+    fn test_proc_stat_field() -> Result<(), Error> {
+        let tempdir = tempfile::tempdir()?;
+        let path = tempdir.path();
+        let mut test_file = fs::File::create(path.join("stat"))?;
+        // PPID: 17, PGRP 23, Session 11 (ignored), TTY 4201, TGPID 7 (ignored)
+        writeln!(
+            test_file,
+            "42 (libproc-rs-mock-process) T 17 23 11 4201 7 ..."
+        )?;
+
+        assert_eq!(proc_stat_field(path, ProcStatField::Ppid), Some(17));
+        assert_eq!(proc_stat_field(path, ProcStatField::Pgrp), Some(23));
+        assert_eq!(proc_stat_field(path, ProcStatField::TtyNr), Some(4201));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_proc_stat_field_errors() -> Result<(), Error> {
+        let tempdir = tempfile::tempdir()?;
+        let path = tempdir.path();
+        let mut test_file = fs::File::create(path.join("stat"))?;
+        // PPID: 17, PGRP 23, Session 11 (ignored), TTY 4201, TGPID 7 (ignored)
+        writeln!(test_file, "garbage in\nerrors out")?;
+
+        assert_eq!(proc_stat_field(path, ProcStatField::Ppid), None);
+        assert_eq!(
+            proc_stat_field(&path.join("nonesuch"), ProcStatField::Ppid),
+            None
+        );
+
+        Ok(())
+    }
+
+    // Compare the (filtered) PID lists with what the procfs library sees. This
+    // won't be a 1:1 match as processes come and go, but it shouldn't deviate
+    // hugely either. Each test is retried multiple times to avoid random
+    // failures.
+
+    const PROCESS_DIFF_TOLERANCE: usize = 5;
+    const MAX_RETRIES: usize = 5;
+
+    #[test]
+    fn test_listpids_all() -> Result<(), procfs::ProcError> {
+        for _ in 0..MAX_RETRIES {
+            let mut procfs_pids: HashSet<_> = procfs::process::all_processes()?
+                .filter_map(|proc| proc.ok().map(|proc| proc.pid))
+                .collect();
+            let mut new_count = 0;
+            let pids = listpids(ProcFilter::All).unwrap_or_default();
+            for pid in pids {
+                if !procfs_pids.remove(&(pid as i32)) {
+                    new_count += 1;
+                }
+            }
+            let gone_count = procfs_pids.len();
+            if new_count < PROCESS_DIFF_TOLERANCE && gone_count < PROCESS_DIFF_TOLERANCE {
+                return Ok(());
+            }
+        }
+        panic!("Test failed");
+    }
+
+    #[test]
+    fn test_listpids_pgid() -> Result<(), procfs::ProcError> {
+        for _ in 0..MAX_RETRIES {
+            let mut procfs_pgrps: HashMap<_, HashSet<_>> = HashMap::new();
+            for proc in (procfs::process::all_processes()?).flatten() {
+                if let Ok(stat) = proc.stat() {
+                    procfs_pgrps
+                        .entry(stat.pgrp)
+                        .and_modify(|pids| {
+                            pids.insert(stat.pid);
+                        })
+                        .or_insert_with(|| vec![stat.pid].into_iter().collect());
+                }
+            }
+            let mut not_matched = 0;
+            for (pgrp, procfs_pids) in procfs_pgrps.iter_mut() {
+                if procfs_pids.len() <= 1 {
+                    continue;
+                }
+                let pids = listpids(ProcFilter::ByProgramGroup {
+                    pgrpid: *pgrp as u32,
+                })
+                .unwrap_or_default();
+                for pid in pids {
+                    if !procfs_pids.remove(&(pid as i32)) {
+                        not_matched += 1;
+                        break;
+                    }
+                }
+                if !procfs_pids.is_empty() {
+                    not_matched += 1;
+                }
+            }
+            if not_matched <= PROCESS_DIFF_TOLERANCE {
+                return Ok(());
+            }
+        }
+        panic!("Test failed");
+    }
+
+    #[test]
+    fn test_listpids_tty() -> Result<(), procfs::ProcError> {
+        for _ in 0..MAX_RETRIES {
+            let mut procfs_ttys: HashMap<_, HashSet<_>> = HashMap::new();
+            for proc in (procfs::process::all_processes()?).flatten() {
+                if let Ok(stat) = proc.stat() {
+                    procfs_ttys
+                        .entry(stat.tty_nr)
+                        .and_modify(|pids| {
+                            pids.insert(stat.pid);
+                        })
+                        .or_insert_with(|| vec![stat.pid].into_iter().collect());
+                }
+            }
+            let mut not_matched = 0;
+            for (tty_nr, procfs_pids) in procfs_ttys.iter_mut() {
+                if procfs_pids.len() <= 1 {
+                    continue;
+                }
+                let pids = listpids(ProcFilter::ByTTY {
+                    tty: *tty_nr as u32,
+                })
+                .unwrap_or_default();
+                for pid in pids {
+                    if !procfs_pids.remove(&(pid as i32)) {
+                        not_matched += 1;
+                        break;
+                    }
+                }
+                if !procfs_pids.is_empty() {
+                    not_matched += 1;
+                }
+            }
+            if not_matched <= PROCESS_DIFF_TOLERANCE {
+                return Ok(());
+            }
+        }
+        panic!("Test failed");
+    }
+
+    #[test]
+    fn test_listpids_uid() -> Result<(), procfs::ProcError> {
+        for _ in 0..MAX_RETRIES {
+            let mut procfs_uids: HashMap<_, HashSet<_>> = HashMap::new();
+            for proc in (procfs::process::all_processes()?).flatten() {
+                if let Ok(status) = proc.status() {
+                    procfs_uids
+                        .entry(status.euid)
+                        .and_modify(|pids| {
+                            pids.insert(status.pid);
+                        })
+                        .or_insert_with(|| vec![status.pid].into_iter().collect());
+                }
+            }
+            let mut not_matched = 0;
+            for (uid, procfs_pids) in procfs_uids.iter_mut() {
+                if procfs_pids.len() <= 1 {
+                    continue;
+                }
+                let pids = listpids(ProcFilter::ByUID { uid: *uid }).unwrap_or_default();
+                for pid in pids {
+                    if !procfs_pids.remove(&(pid as i32)) {
+                        not_matched += 1;
+                        break;
+                    }
+                }
+                if !procfs_pids.is_empty() {
+                    not_matched += 1;
+                }
+            }
+            if not_matched <= PROCESS_DIFF_TOLERANCE {
+                return Ok(());
+            }
+        }
+        panic!("Test failed");
+    }
+
+    #[test]
+    fn test_listpids_real_uid() -> Result<(), procfs::ProcError> {
+        for _ in 0..MAX_RETRIES {
+            let mut procfs_ruids: HashMap<_, HashSet<_>> = HashMap::new();
+            for proc in (procfs::process::all_processes()?).flatten() {
+                if let Ok(status) = proc.status() {
+                    procfs_ruids
+                        .entry(status.ruid)
+                        .and_modify(|pids| {
+                            pids.insert(status.pid);
+                        })
+                        .or_insert_with(|| vec![status.pid].into_iter().collect());
+                }
+            }
+            let mut not_matched = 0;
+            for (ruid, procfs_pids) in procfs_ruids.iter_mut() {
+                if procfs_pids.len() <= 1 {
+                    continue;
+                }
+                let pids = listpids(ProcFilter::ByRealUID { ruid: *ruid }).unwrap_or_default();
+                for pid in pids {
+                    if !procfs_pids.remove(&(pid as i32)) {
+                        not_matched += 1;
+                        break;
+                    }
+                }
+                if !procfs_pids.is_empty() {
+                    not_matched += 1;
+                }
+            }
+            if not_matched <= PROCESS_DIFF_TOLERANCE {
+                return Ok(());
+            }
+        }
+        panic!("Test failed");
+    }
+
+    #[test]
+    fn test_listpids_parent_pid() -> Result<(), procfs::ProcError> {
+        for _ in 0..MAX_RETRIES {
+            let mut procfs_ppids: HashMap<_, HashSet<_>> = HashMap::new();
+            for proc in (procfs::process::all_processes()?).flatten() {
+                if let Ok(stat) = proc.stat() {
+                    procfs_ppids
+                        .entry(stat.ppid)
+                        .and_modify(|pids| {
+                            pids.insert(stat.pid);
+                        })
+                        .or_insert_with(|| vec![stat.pid].into_iter().collect());
+                }
+            }
+            let mut not_matched = 0;
+            for (ppid, procfs_pids) in procfs_ppids.iter_mut() {
+                if procfs_pids.len() <= 1 {
+                    continue;
+                }
+                let pids = listpids(ProcFilter::ByParentProcess { ppid: *ppid as u32 })
+                    .unwrap_or_default();
+                for pid in pids {
+                    if !procfs_pids.remove(&(pid as i32)) {
+                        not_matched += 1;
+                        break;
+                    }
+                }
+                if !procfs_pids.is_empty() {
+                    not_matched += 1;
+                }
+            }
+            if not_matched <= PROCESS_DIFF_TOLERANCE {
+                return Ok(());
+            }
+        }
+        panic!("Test failed");
+    }
+}

--- a/src/libproc/sys/macos.rs
+++ b/src/libproc/sys/macos.rs
@@ -1,0 +1,366 @@
+use std::os::unix::ffi::OsStrExt;
+use std::{ffi, io, mem, path, ptr};
+
+use libc::{c_char, c_void};
+
+use crate::osx_libproc_bindings;
+use crate::processes::ProcFilter;
+
+impl ProcFilter {
+    pub(crate) fn typeinfo(self) -> u32 {
+        match self {
+            ProcFilter::All => 0, // The Darwin kernel ignores the value, it doesn't matter what we pass in
+            ProcFilter::ByProgramGroup { pgrpid } => pgrpid,
+            ProcFilter::ByTTY { tty } => tty,
+            ProcFilter::ByUID { uid } => uid,
+            ProcFilter::ByRealUID { ruid } => ruid,
+            ProcFilter::ByParentProcess { ppid } => ppid,
+        }
+    }
+}
+
+impl From<ProcFilter> for u32 {
+    fn from(proc_type: ProcFilter) -> Self {
+        match proc_type {
+            ProcFilter::All => osx_libproc_bindings::PROC_ALL_PIDS,
+            ProcFilter::ByProgramGroup { .. } => osx_libproc_bindings::PROC_PGRP_ONLY,
+            ProcFilter::ByTTY { .. } => osx_libproc_bindings::PROC_TTY_ONLY,
+            ProcFilter::ByUID { .. } => osx_libproc_bindings::PROC_UID_ONLY,
+            ProcFilter::ByRealUID { .. } => osx_libproc_bindings::PROC_RUID_ONLY,
+            ProcFilter::ByParentProcess { .. } => osx_libproc_bindings::PROC_PPID_ONLY,
+        }
+    }
+}
+
+pub(crate) fn listpids(proc_type: ProcFilter) -> io::Result<Vec<u32>> {
+    let buffer_size = unsafe {
+        osx_libproc_bindings::proc_listpids(
+            proc_type.into(),
+            proc_type.typeinfo(),
+            ptr::null_mut(),
+            0,
+        )
+    };
+    if buffer_size <= 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let capacity = buffer_size as usize / mem::size_of::<u32>();
+    let mut pids: Vec<u32> = Vec::with_capacity(capacity);
+    let buffer_ptr = pids.as_mut_ptr() as *mut c_void;
+
+    let ret = unsafe {
+        osx_libproc_bindings::proc_listpids(
+            proc_type.into(),
+            proc_type.typeinfo(),
+            buffer_ptr,
+            buffer_size,
+        )
+    };
+
+    match ret {
+        value if value <= 0 => Err(io::Error::last_os_error()),
+        _ => {
+            let items_count = ret as usize / mem::size_of::<u32>() - 1;
+            unsafe {
+                pids.set_len(items_count);
+            }
+            Ok(pids)
+        }
+    }
+}
+
+pub(crate) fn listpidspath(
+    proc_type: ProcFilter,
+    path: &path::Path,
+    is_volume: bool,
+    exclude_event_only: bool,
+) -> io::Result<Vec<u32>> {
+    let path_bytes = path.as_os_str().as_bytes();
+    let c_path = ffi::CString::new(path_bytes)
+        .map_err(|_| io::Error::new(io::ErrorKind::Other, "CString::new failed"))?;
+    let mut pathflags: u32 = 0;
+    if is_volume {
+        pathflags |= osx_libproc_bindings::PROC_LISTPIDSPATH_PATH_IS_VOLUME;
+    }
+    if exclude_event_only {
+        pathflags |= osx_libproc_bindings::PROC_LISTPIDSPATH_EXCLUDE_EVTONLY;
+    }
+
+    let buffer_size = unsafe {
+        osx_libproc_bindings::proc_listpidspath(
+            proc_type.into(),
+            proc_type.typeinfo(),
+            c_path.as_ptr() as *const c_char,
+            pathflags,
+            ptr::null_mut(),
+            0,
+        )
+    };
+    if buffer_size <= 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let capacity = buffer_size as usize / mem::size_of::<u32>();
+    let mut pids: Vec<u32> = Vec::with_capacity(capacity);
+    let buffer_ptr = pids.as_mut_ptr() as *mut c_void;
+
+    let ret = unsafe {
+        osx_libproc_bindings::proc_listpidspath(
+            proc_type.into(),
+            proc_type.typeinfo(),
+            c_path.as_ptr() as *const c_char,
+            0,
+            buffer_ptr,
+            buffer_size,
+        )
+    };
+
+    match ret {
+        value if value <= 0 => Err(io::Error::last_os_error()),
+        _ => {
+            let items_count = ret as usize / mem::size_of::<u32>() - 1;
+            unsafe {
+                pids.set_len(items_count);
+            }
+            Ok(pids)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::{HashMap, HashSet};
+    use std::io;
+
+    use super::*;
+
+    use crate::libproc::{bsd_info, proc_pid};
+
+    fn get_all_pid_bsdinfo() -> io::Result<Vec<bsd_info::BSDInfo>> {
+        let pids = listpids(ProcFilter::All)?;
+        Ok(pids
+            .iter()
+            .filter_map(|pid| proc_pid::pidinfo::<bsd_info::BSDInfo>(*pid as i32, 0).ok())
+            .collect())
+    }
+
+    #[test]
+    fn test_listpids() -> io::Result<()> {
+        let pid = std::process::id();
+        let pids = listpids(ProcFilter::All)?;
+        assert!(!pids.is_empty());
+        assert!(pids.contains(&pid));
+        Ok(())
+    }
+
+    // Compare the (filtered) PID lists with what manual filtering with BSDInfo
+    // data. This won't be a 1:1 match as processes come and go, but it
+    // shouldn't deviate hugely either. Each test is retried multiple times to
+    // avoid random failures.
+
+    const PROCESS_DIFF_TOLERANCE: usize = 15;
+    const MAX_RETRIES: usize = 5;
+
+    #[test]
+    fn test_listpids_pgid() -> io::Result<()> {
+        for _ in 0..MAX_RETRIES {
+            let mut bsdinfo_pgrps: HashMap<_, HashSet<_>> = HashMap::new();
+            for info in get_all_pid_bsdinfo()? {
+                if info.pbi_pgid == info.pbi_pid {
+                    continue;
+                }
+                bsdinfo_pgrps
+                    .entry(info.pbi_pgid)
+                    .and_modify(|pids| {
+                        pids.insert(info.pbi_pid);
+                    })
+                    .or_insert_with(|| vec![info.pbi_pid].into_iter().collect());
+            }
+            let mut not_matched = 0;
+            for (pgrp, bsdinfo_pids) in bsdinfo_pgrps.iter_mut() {
+                if bsdinfo_pids.len() <= 1 {
+                    continue;
+                }
+                let pids =
+                    listpids(ProcFilter::ByProgramGroup { pgrpid: *pgrp }).unwrap_or_default();
+                for pid in pids {
+                    if !bsdinfo_pids.remove(&pid) {
+                        not_matched += 1;
+                        break;
+                    }
+                }
+                if !bsdinfo_pids.is_empty() {
+                    not_matched += 1;
+                }
+            }
+            if not_matched <= PROCESS_DIFF_TOLERANCE {
+                return Ok(());
+            }
+        }
+        panic!("Test failed");
+    }
+
+    const NODEV: u32 = u32::MAX;
+
+    #[test]
+    fn test_listpids_tty() -> io::Result<()> {
+        for _ in 0..MAX_RETRIES {
+            let mut bsdinfo_ttys: HashMap<_, HashSet<_>> = HashMap::new();
+            for info in get_all_pid_bsdinfo()? {
+                if info.e_tdev == NODEV || info.e_tpgid == info.pbi_pid {
+                    continue;
+                }
+                bsdinfo_ttys
+                    .entry(info.e_tdev)
+                    .and_modify(|pids| {
+                        pids.insert(info.pbi_pid);
+                    })
+                    .or_insert_with(|| vec![info.pbi_pid].into_iter().collect());
+            }
+            let mut not_matched = 0;
+            for (tty_nr, bsdinfo_pids) in bsdinfo_ttys.iter_mut() {
+                if bsdinfo_pids.len() <= 1 {
+                    continue;
+                }
+                let pids = listpids(ProcFilter::ByTTY { tty: *tty_nr }).unwrap_or_default();
+                for pid in pids {
+                    if !bsdinfo_pids.remove(&pid) {
+                        not_matched += 1;
+                        break;
+                    }
+                }
+                if !bsdinfo_pids.is_empty() {
+                    not_matched += 1;
+                }
+            }
+            if not_matched <= PROCESS_DIFF_TOLERANCE {
+                return Ok(());
+            }
+        }
+        panic!("Test failed");
+    }
+
+    #[test]
+    fn test_listpids_uid() -> io::Result<()> {
+        for _ in 0..MAX_RETRIES {
+            let mut bsdinfo_uids: HashMap<_, HashSet<_>> = HashMap::new();
+            for info in get_all_pid_bsdinfo()? {
+                bsdinfo_uids
+                    .entry(info.pbi_uid)
+                    .and_modify(|pids| {
+                        pids.insert(info.pbi_pid);
+                    })
+                    .or_insert_with(|| vec![info.pbi_pid].into_iter().collect());
+            }
+            let mut not_matched = 0;
+            for (uid, bsdinfo_pids) in bsdinfo_uids.iter_mut() {
+                if bsdinfo_pids.len() <= 1 {
+                    continue;
+                }
+                let pids = listpids(ProcFilter::ByUID { uid: *uid }).unwrap_or_default();
+                for pid in pids {
+                    if !bsdinfo_pids.remove(&pid) {
+                        not_matched += 1;
+                        break;
+                    }
+                }
+                if !bsdinfo_pids.is_empty() {
+                    not_matched += 1;
+                }
+            }
+            if not_matched <= PROCESS_DIFF_TOLERANCE {
+                return Ok(());
+            }
+        }
+        panic!("Test failed");
+    }
+
+    #[test]
+    fn test_listpids_real_uid() -> io::Result<()> {
+        for _ in 0..MAX_RETRIES {
+            let mut bsdinfo_ruids: HashMap<_, HashSet<_>> = HashMap::new();
+            for info in get_all_pid_bsdinfo()? {
+                bsdinfo_ruids
+                    .entry(info.pbi_ruid)
+                    .and_modify(|pids| {
+                        pids.insert(info.pbi_pid);
+                    })
+                    .or_insert_with(|| vec![info.pbi_pid].into_iter().collect());
+            }
+            let mut not_matched = 0;
+            for (ruid, bsdinfo_pids) in bsdinfo_ruids.iter_mut() {
+                if bsdinfo_pids.len() <= 1 {
+                    continue;
+                }
+                let pids = listpids(ProcFilter::ByRealUID { ruid: *ruid }).unwrap_or_default();
+                for pid in pids {
+                    if !bsdinfo_pids.remove(&pid) {
+                        not_matched += 1;
+                        println!("pid {pid} not matched for ruid {ruid}");
+                        break;
+                    }
+                }
+                // PROC_ALL_PIDS and PROC_RUID_ONLY are regulargy not agreeing, with PROC_ALL_PIDS
+                // listing more than PROC_RUID_ONLY for the same ruid. Testing if bsdinfo_pids is
+                // empty is futile here.
+            }
+            if not_matched <= PROCESS_DIFF_TOLERANCE {
+                return Ok(());
+            }
+        }
+        panic!("Test failed");
+    }
+
+    #[test]
+    fn test_listpids_parent_pid() -> io::Result<()> {
+        for _ in 0..MAX_RETRIES {
+            let mut bsdinfo_ppids: HashMap<_, HashSet<_>> = HashMap::new();
+            for info in get_all_pid_bsdinfo()? {
+                bsdinfo_ppids
+                    .entry(info.pbi_ppid)
+                    .and_modify(|pids| {
+                        pids.insert(info.pbi_pid);
+                    })
+                    .or_insert_with(|| vec![info.pbi_pid].into_iter().collect());
+            }
+            let mut not_matched = 0;
+            for (ppid, bsdinfo_pids) in bsdinfo_ppids.iter_mut() {
+                if bsdinfo_pids.len() <= 1 {
+                    continue;
+                }
+                let pids =
+                    listpids(ProcFilter::ByParentProcess { ppid: *ppid }).unwrap_or_default();
+                for pid in pids {
+                    if !bsdinfo_pids.remove(&pid) {
+                        not_matched += 1;
+                        break;
+                    }
+                }
+                // PROC_ALL_PIDS is consistently producing processes that are
+                // not listed by PROC_PPID_ONLY, so we can't make assertions
+                // about having matched all child processes. There is no
+                // signal that I can see on why this is.
+            }
+            if not_matched <= PROCESS_DIFF_TOLERANCE {
+                return Ok(());
+            }
+        }
+        panic!("Test failed");
+    }
+
+    // No point in writing test cases for all ProcFilter members, as the Darwin
+    // implementation of proc_listpidspath is essentially a wrapper acound
+    // proc_listpids with calls to proc_pidinfo to gather path information.
+    // Tests here would simply repeat that work, and so in essence *test the
+    // Darwin libproc library* and not our wrapping of that library.
+
+    #[test]
+    fn test_listpidspath() -> Result<(), io::Error> {
+        let root = std::path::Path::new("/");
+        let pids =
+            listpidspath(ProcFilter::All, root, true, false).expect("Failed to load PIDs for path");
+        assert!(!pids.is_empty());
+        Ok(())
+    }
+}

--- a/src/libproc/sys/mod.rs
+++ b/src/libproc/sys/mod.rs
@@ -1,0 +1,10 @@
+// OS-specific implementations of process-related functions
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub(crate) use self::linux::*;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub(crate) use self::macos::*;

--- a/src/processes.rs
+++ b/src/processes.rs
@@ -1,0 +1,164 @@
+use std::io;
+#[cfg(target_os = "macos")]
+use std::path::Path;
+
+use crate::libproc::sys::*;
+
+/// `ProcFilter` is used to filter process ids. See [`pids_by_type`] and
+/// [`pids_by_type_and_path`] for details.
+#[derive(Copy, Clone)]
+pub enum ProcFilter {
+    /// All processes
+    All,
+    /// Filter by program group id
+    ByProgramGroup {
+        /// List PIDs that are members of this process group
+        pgrpid: u32,
+    },
+    /// Filter by TTY
+    ByTTY {
+        /// List PIDs attached to the specific TTY
+        tty: u32,
+    },
+    /// Filter by (effective) user ID
+    ByUID {
+        /// List PIDs of processes with the permissions of this specific user.
+        uid: u32,
+    },
+    /// Filter by real user ID
+    ByRealUID {
+        /// List PIDs of processes started by this specific user.
+        ruid: u32,
+    },
+    /// Filter by parent process ID
+    ByParentProcess {
+        /// List PIDs of processes that are children of this specific process.
+        ppid: u32,
+    },
+}
+
+/// Returns the PIDs of active processes that match the given [`ProcFilter`] filter.
+///
+/// # Examples
+///
+/// Get the list of all running process IDs using `pids_by_type` and `ProcFilter::All`:
+///
+/// ```
+/// use std::io::Write;
+/// use libproc::processes;
+///
+/// if let Ok(pids) = processes::pids_by_type(processes::ProcFilter::All) {
+///     println!("There are {} processes running on this system", pids.len());
+/// }
+/// ```
+///
+/// Get a list of running process IDs that are children of the current process:
+///
+/// ```
+/// use std::io::Write;
+/// use std::process;
+/// use libproc::processes;
+///
+/// let filter = processes::ProcFilter::ByParentProcess { ppid: process::id() };
+/// if let Ok(pids) = processes::pids_by_type(filter) {
+///     println!("Found {} child processes of this process", pids.len());
+/// }
+/// ```
+pub fn pids_by_type(filter: ProcFilter) -> io::Result<Vec<u32>> {
+    listpids(filter)
+}
+
+/// Returns the PIDs of active processes that reference reference an open file
+/// with the given path or volume, with or without files opened with the
+/// `O_EVTONLY` flag.
+///
+/// (Files opened with the `O_EVTONLY` flag will not prevent a volume from being
+/// unmounted).
+///
+/// # Examples
+///
+/// Get the list of all running process IDs that have a specific filename open:
+///
+/// ```
+/// use std::path::Path;
+/// use std::io::Write;
+/// use libproc::processes;
+///
+/// let path = Path::new("/etc/hosts");
+/// if let Ok(pids) = processes::pids_by_path(&path, false, false) {
+///     println!("Found {} processes accessing {}", pids.len(), path.display());
+/// }
+/// ```
+///
+/// List all processes that have a file open on a specific volume; the path
+/// argument is used to get the filesystem device ID, and processes that have
+/// a file open on that same device ID match the filter:
+/// ```
+/// use std::path::Path;
+/// use std::io::Write;
+/// use libproc::processes;
+///
+/// let path = Path::new("/Volumes/MountedDrive");
+/// if let Ok(pids) = processes::pids_by_path(&path, true, false) {
+///     println!("Found {} processes accessing files on {}", pids.len(), path.display());
+/// }
+/// ```
+#[cfg(target_os = "macos")]
+pub fn pids_by_path(
+    path: &Path,
+    is_volume: bool,
+    exclude_event_only: bool,
+) -> io::Result<Vec<u32>> {
+    listpidspath(ProcFilter::All, path, is_volume, exclude_event_only)
+}
+
+/// Returns a filtered list of PIDs of active processes that reference reference
+/// an open file with the given path or volume, with or without files opened
+/// with the `O_EVTONLY` flag. Use a [`ProcFilter`] member to specify how to
+/// filter the list of PIDs returned.
+///
+/// (Files opened with the `O_EVTONLY` flag will not prevent a volume from being
+/// unmounted).
+///
+/// # Examples
+///
+/// Get the list of process ids for child processes that have a specific filename open:
+///
+/// ```
+/// use std::path::Path;
+/// use std::process;
+/// use std::io::Write;
+/// use libproc::processes;
+///
+/// let path = Path::new("/etc/hosts");
+/// let filter = processes::ProcFilter::ByParentProcess { ppid: process::id() };
+/// if let Ok(pids) = processes::pids_by_type_and_path(filter, &path, false, false) {
+///     println!("Found {} processes accessing {}", pids.len(), path.display());
+/// }
+/// ```
+///
+/// List all processes within the current process group that have a file open on
+/// a specific volume; the path argument is used to get the filesystem device
+/// ID, and processes that have a file open on that same device ID match the
+/// filter:
+/// ```
+/// use std::path::Path;
+/// use std::process;
+/// use std::io::Write;
+/// use libproc::processes;
+///
+/// let path = Path::new("/Volumes/MountedDrive");
+/// let filter = processes::ProcFilter::ByParentProcess { ppid: process::id() };
+/// if let Ok(pids) = processes::pids_by_type_and_path(filter, &path, true, false) {
+///     println!("Found {} processes accessing files on {}", pids.len(), path.display());
+/// }
+/// ```
+#[cfg(target_os = "macos")]
+pub fn pids_by_type_and_path(
+    filter: ProcFilter,
+    path: &Path,
+    is_volume: bool,
+    exclude_event_only: bool,
+) -> io::Result<Vec<u32>> {
+    listpidspath(filter, path, is_volume, exclude_event_only)
+}

--- a/src/procinfo.rs
+++ b/src/procinfo.rs
@@ -30,6 +30,7 @@ use std::env;
 use std::io::Write;
 use libproc::libproc::proc_pid;
 use libproc::libproc::pid_rusage::{pidrusage, RUsageInfoV0};
+use libproc::processes;
 
 mod c {
     extern crate libc;
@@ -72,7 +73,7 @@ fn procinfo(pid: i32) {
         Err(err) => writeln!(&mut std::io::stderr(), "Error: {err}").unwrap()
     }
 
-    match proc_pid::listpids(proc_pid::ProcType::ProcAllPIDS) {
+    match processes::pids_by_type(processes::ProcFilter::All) {
         Ok(pids) => {
             println!("There are currently {} processes active", pids.len());
             for pid in pids {


### PR DESCRIPTION
This re-works the `proc_listpids` and `proc_listpidspath` API wrappers to pass along the correct typeinfo value for each proc type, under the new `libproc::processes` module.

This includes a per-os `sys` module to factor out platform-specific code into separate modules, and a Linux re-implementation of the `proc_listpids` filters on top of procfs. 

I've updated the version number to 0.13 and 

Fixes #85 