### PR TITLE
I was rewriting a process tree mapping program from C, and noticed th…

### DIFF
--- a/src/libproc/sys/macos.rs
+++ b/src/libproc/sys/macos.rs
@@ -61,7 +61,7 @@ pub(crate) fn listpids(proc_type: ProcFilter) -> io::Result<Vec<u32>> {
     match ret {
         value if value <= 0 => Err(io::Error::last_os_error()),
         _ => {
-            let items_count = ret as usize / mem::size_of::<u32>() - 1;
+            let items_count = ret as usize / mem::size_of::<u32>();
             unsafe {
                 pids.set_len(items_count);
             }
@@ -119,7 +119,7 @@ pub(crate) fn listpidspath(
     match ret {
         value if value <= 0 => Err(io::Error::last_os_error()),
         _ => {
-            let items_count = ret as usize / mem::size_of::<u32>() - 1;
+            let items_count = ret as usize / mem::size_of::<u32>();
             unsafe {
                 pids.set_len(items_count);
             }


### PR DESCRIPTION
…at for a ppid with a single child, I would get an empty list using 'let pids = pids_by_type(libproc::processes::ProcFilter::ByParentProcess { ppid: MY_PROC_PID }).unwrap();'. Where the same direct call in C would yield a list with 1 PID. Digging into libproc-rs, I noticed that the size was being adjusted -1, and when corrected I now see the correct single child pid.

One worrisome thing is what is happening now when there are actually zero children for a PID? I think it's producing an error.