### PR TITLE
Bump version number for 0.14.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libproc"
-version = "0.14.2"
+version = "0.14.3"
 description = "A library to get information about running processes - for Mac OS X and Linux"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 repository = "https://github.com/andrewdavidmackenzie/libproc-rs"


### PR DESCRIPTION
Prior to releasing 0.14.3 with a bux fix in listpids