### PR TITLE
loosen minimum rust version requirement

### DIFF
--- a/.github/workflows/clippy_build_test.yml
+++ b/.github/workflows/clippy_build_test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-11, macos-12, macos-13, macos-14 ]
-        rust: [stable, beta, 1.74.1] # Minimum Rust Version Supported = 1.74.1
+        rust: [stable, beta, 1.72.0] # Minimum Rust Version Supported = 1.72.0
         experimental: [false]
         include:
           - os: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ You can find the browseable docs for the latest release on [docs.rs](https://doc
 NOTE: `master` branch (code and docs) can differ from those docs prior to a new release.
 
 # Minimum rust version
-The minimum rust version required is currently: 1.74.1 and this is tested in CI and must pass.
+The minimum rust version required, by version:
+* libproc-rs: 0.14.6 --> 1.74.1 
+* libproc-rs: 0.14.7 --> 1.72.0
+This is tested in CI and must pass.
 
 # Test Matrix
 The Github Actions CI matrix is:

--- a/README.md
+++ b/README.md
@@ -88,10 +88,14 @@ I put the "help wanted" label where I need help from others.
 - Add own custom error type and implement From::from to ease reporting of multiple error types in clients
 
 ## Build and Test Locally
-If you're feeling lucky today, start with 
-`make`
+If you're feeling lucky today, start with `make`
+that will run `clippy`, `test` and will build docs also.
 
-`cargo test` will build and test as usual.
+If you want to test locally as much of the test matrix as possible (different OS and
+versions of rust), that you can use `make matrix`. On macos, if you have `act`
+installed, it will use it to run the linux part of the matrix.
+
+If you want to stay "pure rust" : `cargo test` will build and test as usual.
 
 However, as some functions need to be run as `root` to work, CI tests are run as `root`.
 So, when developing in local it's best if you use `sudo cargo test`.
@@ -108,8 +112,9 @@ If you develop on macos but want to ensure code builds and tests pass on linux w
 you can use the [act](https://github.com/nektos/act) tool to run the Github Actions Workflows on
 the test matrix.
 
-Just install "act" (`brew install act`) (previously install docker if you don't have it already,
-and make sure the daemon is running) then run `act` at the command line
+Just install `act` (`brew install act`) (previously install docker if you don't have it already,
+and make sure the daemon is running) then run `act -W .github/workflows/clippy_build_test.yml`
+at the command line
 
 ### Macos: clang detection and header file finding
 Newer versions of `bindgen` have improved the detection of `clang` and hence macos header files.


### PR DESCRIPTION
I loosened the minimum rust version requirement after finding the previous version that worked without any code changes.

I also updated a little the README.md in this area and introduced a 'matrix' make target that helps developers test as much of the matrix locally as they can.