### PR TITLE
Add ThreadInfo and WorkQueueInfo examples and tests

### DIFF
--- a/src/libproc/file_info.rs
+++ b/src/libproc/file_info.rs
@@ -87,8 +87,8 @@ impl From<u32> for ProcFDType {
     }
 }
 
-/// The `PIDFDInfo` trait is needed for polymorphism on pidfdinfo types, also abstracting flavor in order to provide
-/// type-guaranteed flavor correctness
+/// The `PIDFDInfo` trait is needed for polymorphism on pidfdinfo types, also abstracting flavor
+/// in order to provide type-guaranteed flavor correctness
 pub trait PIDFDInfo: Default {
     /// Return the Pid File Descriptor Info flavor of the implementing struct
     fn flavor() -> PIDFDInfoFlavor;
@@ -117,10 +117,12 @@ pub trait PIDFDInfo: Default {
 /// let _listener = TcpListener::bind("127.0.0.1:8000");
 ///
 /// let info = pidinfo::<BSDInfo>(pid, 0).expect("Could not get BSDInfo on {pid}");///
-/// let fds = listpidinfo::<ListFDs>(pid, info.pbi_nfiles as usize).expect("Could not list FD of {pid}");
+/// let fds = listpidinfo::<ListFDs>(pid, info.pbi_nfiles as usize)
+///     .expect("Could not list FD of {pid}");
 /// for fd in &fds {
 ///     if let(ProcFDType::Socket) = fd.proc_fdtype.into() {
-///         let socket = pidfdinfo::<SocketFDInfo>(pid, fd.proc_fd).expect("Could not get SocketFDInfo");
+///         let socket = pidfdinfo::<SocketFDInfo>(pid, fd.proc_fd)
+///             .expect("Could not get SocketFDInfo");
 ///         if let(SocketInfoKind::Tcp) = socket.psi.soi_kind.into() {
 ///             // access to the member of `soi_proto` is unsafe becasuse of union type.
 ///             let info = unsafe { socket.psi.soi_proto.pri_tcp };
@@ -140,7 +142,8 @@ pub trait PIDFDInfo: Default {
 ///             addr |= s_addr << 8  & 0x00ff0000;
 ///             addr |= s_addr << 24 & 0xff000000;
 ///
-///             println!("{}.{}.{}.{}:{}", addr >> 24 & 0xff, addr >> 16 & 0xff, addr >> 8 & 0xff, addr & 0xff, port);
+///             println!("{}.{}.{}.{}:{}", addr >> 24 & 0xff, addr >> 16 & 0xff, addr >> 8 & 0xff,
+///                         addr & 0xff, port);
 ///         }
 ///     }
 /// }

--- a/src/libproc/file_info.rs
+++ b/src/libproc/file_info.rs
@@ -121,34 +121,30 @@ pub trait PIDFDInfo: Default {
 /// for fd in &fds {
 ///     if let(ProcFDType::Socket) = fd.proc_fdtype.into() {
 ///         let socket = pidfdinfo::<SocketFDInfo>(pid, fd.proc_fd).expect("Could not get SocketFDInfo");
-///         match socket.psi.soi_kind.into() {
-///             SocketInfoKind::Tcp => {
-///                 // access to the member of `soi_proto` is unsafe becasuse of union type.
-///                 let info = unsafe { socket.psi.soi_proto.pri_tcp };
+///         if let(SocketInfoKind::Tcp) = socket.psi.soi_kind.into() {
+///             // access to the member of `soi_proto` is unsafe becasuse of union type.
+///             let info = unsafe { socket.psi.soi_proto.pri_tcp };
 ///
-///                 // change endian and cut off because insi_lport is network endian and 16bit witdh.
-///                 let mut port = 0;
-///                 port |= info.tcpsi_ini.insi_lport >> 8 & 0x00ff;
-///                 port |= info.tcpsi_ini.insi_lport << 8 & 0xff00;
+///             // change endian and cut off because insi_lport is network endian and 16bit witdh.
+///             let mut port = 0;
+///             port |= info.tcpsi_ini.insi_lport >> 8 & 0x00ff;
+///             port |= info.tcpsi_ini.insi_lport << 8 & 0xff00;
 ///
-///                 // access to the member of `insi_laddr` is unsafe becasuse of union type.
-///                 let s_addr = unsafe { info.tcpsi_ini.insi_laddr.ina_46.i46a_addr4.s_addr };
+///             // access to the member of `insi_laddr` is unsafe becasuse of union type.
+///             let s_addr = unsafe { info.tcpsi_ini.insi_laddr.ina_46.i46a_addr4.s_addr };
 ///
-///                 // change endian because insi_laddr is network endian.
-///                 let mut addr = 0;
-///                 addr |= s_addr >> 24 & 0x000000ff;
-///                 addr |= s_addr >> 8  & 0x0000ff00;
-///                 addr |= s_addr << 8  & 0x00ff0000;
-///                 addr |= s_addr << 24 & 0xff000000;
+///             // change endian because insi_laddr is network endian.
+///             let mut addr = 0;
+///             addr |= s_addr >> 24 & 0x000000ff;
+///             addr |= s_addr >> 8  & 0x0000ff00;
+///             addr |= s_addr << 8  & 0x00ff0000;
+///             addr |= s_addr << 24 & 0xff000000;
 ///
-///                 println!("{}.{}.{}.{}:{}", addr >> 24 & 0xff, addr >> 16 & 0xff, addr >> 8 & 0xff, addr & 0xff, port);
-///             }
-///             _ => (),
+///             println!("{}.{}.{}.{}:{}", addr >> 24 & 0xff, addr >> 16 & 0xff, addr >> 8 & 0xff, addr & 0xff, port);
 ///         }
 ///     }
 /// }
 /// ```
-///
 #[cfg(target_os = "macos")]
 pub fn pidfdinfo<T: PIDFDInfo>(pid: i32, fd: i32) -> Result<T, String> {
     let flavor = T::flavor() as i32;

--- a/src/libproc/proc_pid.rs
+++ b/src/libproc/proc_pid.rs
@@ -206,7 +206,7 @@ pub fn listpidspath(proc_types: ProcType, path: &str) -> Result<Vec<u32>, String
 
 /// Get info about a process, task, thread or work queue by specifying the appropriate type for `T`:
 /// - `BSDInfo`
-/// - `TaskInfo`
+/// - `TaskInfo` - see struct `proc_taskinfo` in generated `osx_libproc_bindings.rs`
 /// - `TaskAllInfo`
 /// - `ThreadInfo`
 /// - `WorkQueueInfo`
@@ -219,15 +219,22 @@ pub fn listpidspath(proc_types: ProcType, path: &str) -> Result<Vec<u32>, String
 ///
 /// ```
 /// use std::io::Write;
-/// use libproc::libproc::proc_pid::pidinfo;
-/// use libproc::libproc::bsd_info::BSDInfo;
+/// use libproc::proc_pid::pidinfo;
+/// use libproc::bsd_info::BSDInfo;
+/// use libproc::task_info::TaskInfo;
 /// use std::process;
 ///
 /// let pid = process::id() as i32;
 ///
-/// // Get the `BSDInfo` for Process of pid 0
+/// // Get the `BSDInfo` for process with pid 0
 /// match pidinfo::<BSDInfo>(pid, 0) {
 ///     Ok(info) => assert_eq!(info.pbi_pid as i32, pid),
+///     Err(err) => eprintln!("Error retrieving process info: {}", err)
+/// };
+///
+/// // Get the `TaskInfo` for process with pid 0
+/// match pidinfo::<TaskInfo>(pid, 0) {
+///     Ok(info) => assert!(info.pti_threadnum  > 0),
 ///     Err(err) => eprintln!("Error retrieving process info: {}", err)
 /// };
 /// ```

--- a/src/libproc/proc_pid.rs
+++ b/src/libproc/proc_pid.rs
@@ -209,7 +209,7 @@ pub fn listpidspath(proc_types: ProcType, path: &str) -> Result<Vec<u32>, String
 /// - `TaskInfo` - see struct `proc_taskinfo` in generated `osx_libproc_bindings.rs`
 /// - `TaskAllInfo` - see struct `TaskAllInfo` in `task_info.rs` that contains the two structs above
 /// - `ThreadInfo` - see struct `proc_threadinfo` in generated `osx_libproc_bindings.rs`
-/// - `WorkQueueInfo`
+/// - `WorkQueueInfo` - see struct `proc_workqueueinfo` in generated `osx_libproc_bindings.rs`
 ///
 /// # Errors
 ///
@@ -224,6 +224,7 @@ pub fn listpidspath(proc_types: ProcType, path: &str) -> Result<Vec<u32>, String
 /// use libproc::task_info::{TaskAllInfo, TaskInfo};
 /// use std::process;
 /// use libproc::thread_info::ThreadInfo;
+/// use libproc::work_queue_info::WorkQueueInfo;
 ///
 /// let pid = process::id() as i32;
 ///
@@ -251,6 +252,12 @@ pub fn listpidspath(proc_types: ProcType, path: &str) -> Result<Vec<u32>, String
 /// // Get the `ThreadInfo` for process with pid 0
 /// match pidinfo::<ThreadInfo>(pid, 0) {
 ///     Ok(info) => assert!(!info.pth_name.is_empty()),
+///     Err(err) => eprintln!("Error retrieving process info: {}", err)
+/// };
+///
+/// // Get the `WorkQueueInfo` for process with pid 0
+/// match pidinfo::<WorkQueueInfo>(pid, 0) {
+///     Ok(info) => assert!(info.pwq_nthreads > 0),
 ///     Err(err) => eprintln!("Error retrieving process info: {}", err)
 /// };
 /// ```
@@ -706,9 +713,7 @@ mod test {
     #[cfg(target_os = "macos")]
     #[test]
     fn workqueueinfo_test() {
-        let pid = process::id() as i32;
-
-        match pidinfo::<WorkQueueInfo>(pid, 0) {
+        match pidinfo::<WorkQueueInfo>(0, 0) {
             Ok(info) => assert!(info.pwq_nthreads > 0),
             Err(e) => panic!("{}: {}", "Error retrieving WorkQueueInfo", e),
         };

--- a/src/libproc/proc_pid.rs
+++ b/src/libproc/proc_pid.rs
@@ -709,11 +709,10 @@ mod test {
         };
     }
 
-    #[ignore]
     #[cfg(target_os = "macos")]
     #[test]
     fn workqueueinfo_test() {
-        match pidinfo::<WorkQueueInfo>(0, 0) {
+        match pidinfo::<WorkQueueInfo>(1, 0) {
             Ok(info) => assert!(info.pwq_nthreads > 0),
             Err(e) => panic!("{}: {}", "Error retrieving WorkQueueInfo", e),
         };


### PR DESCRIPTION
Fixes #73

By adding tests and doc tests that query ThreadInfo and WorkQueueInfo on pid 0