### PR TITLE
fix: use CARGO_CFG_TARGET_OS for cross-compilation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT"
 edition = "2018"
 rust-version = "1.72"
 
+[lints.clippy]
+pedantic = "deny"
+
 [dependencies]
 errno = "0.3.14"
 libc = "^0.2.176"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libproc"
-version = "0.14.10"
+version = "0.14.11"
 description = "A library to get information about running processes - for Mac OS X and Linux"
 authors = ["Andrew Mackenzie <andrew@mackenzie-serres.net>"]
 repository = "https://github.com/andrewdavidmackenzie/libproc-rs"
@@ -11,23 +11,23 @@ edition = "2018"
 rust-version = "1.72"
 
 [dependencies]
-errno = "0.3.0"
-libc = "^0.2.62"
+errno = "0.3.14"
+libc = "^0.2.176"
 
 [lib]
 name = "libproc"
 path = "src/lib.rs"
 
 [build-dependencies]
-bindgen = { version = "0.72.0", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.72.1", default-features = false, features = ["runtime"] }
 
 # NOTE: This assumes that there is a procfs compatible FS in redox and the procfs crate
-# supports it. It's quite probably that neither of those two things ever happen.
+# supports it. It's quite probably that neither of those two things will ever happen.
 # But making this assumption for now so that everything compiles at least for redox
 [target.'cfg(any(target_os = "linux", target_os = "redox", target_os = "android"))'.dev-dependencies]
 procfs = "0.18.0"
 tempfile = "3.3.0"
 
-# Build docs for macos and linux
+# Build docs for macOS and linux
 [package.metadata.docs.rs]
 targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a library for getting information about running processes for Mac OS X a
 
 Add it to your project's `Cargo.toml`:
 ```toml
-libproc = "0.14.4"
+libproc = "0.14.11"
 ```
 
 And then use it in your code:
@@ -29,6 +29,7 @@ NOTE: `master` branch (code and docs) can differ from those docs prior to a new 
 The minimum rust version required, by version:
 * libproc-rs: 0.14.6 --> 1.74.1 
 * libproc-rs: 0.14.7 --> 1.72.0
+* libproc-rs: 0.14.11 --> 1.72.0
 
 This is tested in CI and must pass.
 

--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,26 @@
-#[cfg(target_os = "macos")]
 fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "macos" {
+        build_macos_bindings();
+    }
+}
+
+fn build_macos_bindings() {
     use bindgen::{RustEdition, RustTarget};
     use std::env;
     use std::path::Path;
 
     match RustTarget::stable(72, 0) {
         Ok(rust_target) => {
+            let sdk_path = env::var("SDKROOT")
+                .unwrap_or_else(|_| "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk".into());
+
             let bindings = bindgen::builder()
                 .header_contents("libproc_rs.h", "#include <libproc.h>")
                 .rust_target(rust_target)
                 .rust_edition(RustEdition::Edition2018)
                 .layout_tests(false)
-                .clang_args(&["-x", "c++", "-I", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/"])
+                .clang_args(&["-x", "c++", "-I", &format!("{}/usr/include/", sdk_path)])
                 .generate()
                 .expect("Failed to build libproc bindings");
 
@@ -26,6 +35,3 @@ fn main() {
         _ => eprintln!("Error executing bindgen")
     }
 }
-
-#[cfg(any(target_os = "linux", target_os = "redox", target_os = "android"))]
-fn main() {}

--- a/build.rs
+++ b/build.rs
@@ -20,18 +20,18 @@ fn build_macos_bindings() {
                 .rust_target(rust_target)
                 .rust_edition(RustEdition::Edition2018)
                 .layout_tests(false)
-                .clang_args(&["-x", "c++", "-I", &format!("{}/usr/include/", sdk_path)])
+                .clang_args(&["-x", "c++", "-I", &format!("{sdk_path}/usr/include/")])
                 .generate()
                 .expect("Failed to build libproc bindings");
 
-            let output_path = Path::new(&env::var("OUT_DIR")
-                .expect("OUT_DIR env var was not defined"))
-                .join("osx_libproc_bindings.rs");
+            let output_path =
+                Path::new(&env::var("OUT_DIR").expect("OUT_DIR env var was not defined"))
+                    .join("osx_libproc_bindings.rs");
 
             bindings
                 .write_to_file(output_path)
                 .expect("Failed to write libproc bindings");
         }
-        _ => eprintln!("Error executing bindgen")
+        _ => eprintln!("Error executing bindgen"),
     }
 }

--- a/src/libproc/file_info.rs
+++ b/src/libproc/file_info.rs
@@ -177,12 +177,12 @@ pub fn pidfdinfo<T: PIDFDInfo>(_pid: i32, _fd: i32) -> Result<T, String> {
 
 #[cfg(all(test, target_os = "macos"))]
 mod test {
+    use super::pidfdinfo;
     use crate::libproc::bsd_info::BSDInfo;
     use crate::libproc::file_info::{ListFDs, ProcFDType};
     use crate::libproc::net_info::{SocketFDInfo, SocketInfoKind};
     use crate::libproc::proc_pid::{listpidinfo, pidinfo};
     use std::process;
-    use super::pidfdinfo;
 
     #[test]
     #[allow(clippy::cast_possible_wrap)]

--- a/src/libproc/pid_rusage.rs
+++ b/src/libproc/pid_rusage.rs
@@ -384,7 +384,7 @@ pub fn pidrusage<T: PIDRUsage>(pid: i32) -> Result<T, String> {
     let flavor = T::flavor() as i32;
     let mut pidrusage = T::default();
     #[allow(clippy::pedantic)]
-        let buffer_ptr = &mut pidrusage as *mut _ as *mut c_void;
+    let buffer_ptr = &mut pidrusage as *mut _ as *mut c_void;
     let ret: i32;
 
     unsafe {

--- a/src/libproc/sys/linux.rs
+++ b/src/libproc/sys/linux.rs
@@ -185,7 +185,7 @@ mod test {
                 let pids = listpids(ProcFilter::ByProgramGroup {
                     pgrpid: *pgrp as u32,
                 })
-                    .unwrap_or_default();
+                .unwrap_or_default();
                 for pid in pids {
                     if !procfs_pids.remove(&(pid as i32)) {
                         not_matched += 1;
@@ -225,7 +225,7 @@ mod test {
                 let pids = listpids(ProcFilter::ByTTY {
                     tty: *tty_nr as u32,
                 })
-                    .unwrap_or_default();
+                .unwrap_or_default();
                 for pid in pids {
                     if !procfs_pids.remove(&(pid as i32)) {
                         not_matched += 1;


### PR DESCRIPTION
Replace #[cfg(target_os)] with CARGO_CFG_TARGET_OS runtime check. The cfg attribute checks HOST OS, not TARGET OS, which breaks cross-compilation from Linux to macOS.
