### PR TITLE
Add kproc_info() for PID 0 (kernel_task) support on macOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,11 @@ pub use libproc::thread_info;
 /// Get information about Work Queues
 pub use libproc::work_queue_info;
 
+#[cfg(any(target_os = "macos", doc))]
+#[doc(inline)]
+/// Get process information via `sysctl(KERN_PROC_PID)` - works for PID 0 (`kernel_task`)
+pub use libproc::kinfo;
+
 // Not documenting this as this export is legacy, and replaced by all the re-exports of
 // sub-modules above
 #[doc(hidden)]

--- a/src/libproc/kinfo.rs
+++ b/src/libproc/kinfo.rs
@@ -1,0 +1,222 @@
+//! `kinfo` module
+//!
+//! Process information obtained via `sysctl(KERN_PROC_PID)`. Unlike the
+//! `proc_pidinfo`-based APIs, this works for PID 0 (`kernel_task`) and does not
+//! require root for basic process information.
+//!
+//! Two types are provided:
+//! - [`KProcInfo`](crate::libproc::kinfo::KProcInfo) — a friendly, owned wrapper
+//!   with named scalar fields.
+//! - [`KinfoProc`](crate::libproc::kinfo::KinfoProc) — a faithful `#[repr(C)]`
+//!   mirror of the macOS `kinfo_proc` structure (`struct extern_proc` +
+//!   `struct eproc`) for callers that need the raw kernel data.
+//!
+//! The raw structures are defined here (rather than relying on the `libc` crate)
+//! because `libc` no longer exposes `kinfo_proc` for Apple targets. They mirror
+//! the layout in `<sys/sysctl.h>` exactly so that `sysctl` fills them correctly.
+//!
+//! See [`crate::libproc::proc_pid::kproc_info`] and
+//! [`crate::libproc::proc_pid::kproc_info_raw`].
+
+use std::os::raw::c_void;
+
+// Raw `#[repr(C)]` mirrors of the macOS kernel structures. Field names, types and
+// order match `<sys/sysctl.h>` (as captured from the verified Apple definitions).
+// Most fields are never read by consumers, so the raw structs are exempted from
+// `missing_docs`, mirroring how this crate treats its other FFI bindings.
+
+/// `struct timeval` (mirrored to avoid depending on a `libc` alias).
+#[allow(missing_docs)]
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Timeval {
+    pub tv_sec: i64,
+    pub tv_usec: i32,
+}
+
+/// `struct itimerval` (mirrored).
+#[allow(missing_docs)]
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct Itimerval {
+    pub it_interval: Timeval,
+    pub it_value: Timeval,
+}
+
+/// Mirror of macOS `struct extern_proc` (the `kp_proc` member of `kinfo_proc`).
+#[allow(missing_docs)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ExternProc {
+    // `union p_un` from the system header (process start time / scheduling links).
+    // Represented by its 16-byte, 8-byte-aligned `timeval` member; never read here.
+    pub p_un: Timeval,
+    pub p_vmspace: *mut c_void,
+    pub p_sigacts: usize,
+    pub p_flag: i32,
+    pub p_stat: i8,
+    pub p_pid: i32,
+    pub p_oppid: i32,
+    pub p_dupfd: i32,
+    pub user_stack: *mut c_void,
+    pub exit_thread: *mut c_void,
+    pub p_debugger: i32,
+    pub sigwait: i32,
+    pub p_estcpu: u32,
+    pub p_cpticks: i32,
+    pub p_pctcpu: u32,
+    pub p_wchan: *mut c_void,
+    pub p_wmesg: *mut c_void,
+    pub p_swtime: u32,
+    pub p_slptime: u32,
+    pub p_realtimer: Itimerval,
+    pub p_rtime: Timeval,
+    pub p_uticks: u64,
+    pub p_sticks: u64,
+    pub p_iticks: u64,
+    pub p_traceflag: i32,
+    pub p_tracep: *mut c_void,
+    pub p_siglist: i32,
+    pub p_textvp: *mut c_void,
+    pub p_holdcnt: i32,
+    pub p_sigmask: u32,
+    pub p_sigignore: u32,
+    pub p_sigcatch: u32,
+    pub p_priority: u8,
+    pub p_usrpri: u8,
+    pub p_nice: i8,
+    pub p_comm: [i8; 17],
+    pub p_pgrp: *mut c_void,
+    pub p_addr: *mut c_void,
+    pub p_xstat: u16,
+    pub p_acflag: u16,
+    pub p_ru: *mut c_void,
+}
+
+/// Mirror of macOS `struct _pcred` (process credentials).
+#[allow(missing_docs)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Pcred {
+    pub pc_lock: [i8; 72],
+    pub pc_ucred: *mut c_void,
+    pub p_ruid: u32,
+    pub p_svuid: u32,
+    pub p_rgid: u32,
+    pub p_svgid: u32,
+    pub p_refcnt: i32,
+}
+
+/// Mirror of macOS `struct _ucred` (user credentials).
+#[allow(missing_docs)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Ucred {
+    pub cr_ref: i32,
+    pub cr_uid: u32,
+    pub cr_ngroups: i16,
+    pub cr_groups: [u32; 16],
+}
+
+/// Mirror of macOS `struct vmspace` (opaque placeholder, as in the system header).
+#[allow(missing_docs)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Vmspace {
+    pub dummy: i32,
+    pub dummy2: *mut c_void,
+    pub dummy3: [i32; 5],
+    pub dummy4: [*mut c_void; 3],
+}
+
+/// Mirror of macOS `struct eproc` (the `kp_eproc` member of `kinfo_proc`).
+#[allow(missing_docs)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Eproc {
+    pub e_paddr: *mut c_void,
+    pub e_sess: *mut c_void,
+    pub e_pcred: Pcred,
+    pub e_ucred: Ucred,
+    pub e_vm: Vmspace,
+    pub e_ppid: i32,
+    pub e_pgid: i32,
+    pub e_jobc: i16,
+    pub e_tdev: i32,
+    pub e_tpgid: i32,
+    pub e_tsess: *mut c_void,
+    pub e_wmesg: [i8; 8],
+    pub e_xsize: i32,
+    pub e_xrssize: i16,
+    pub e_xccount: i16,
+    pub e_xswrss: i16,
+    pub e_flag: i32,
+    pub e_login: [i8; 12],
+    pub e_spare: [i32; 4],
+}
+
+/// Faithful `#[repr(C)]` mirror of the macOS `kinfo_proc` structure returned by
+/// `sysctl(KERN_PROC_PID)`.
+///
+/// Use [`crate::libproc::proc_pid::kproc_info`] for a friendly wrapper, or
+/// [`crate::libproc::proc_pid::kproc_info_raw`] to obtain this raw structure.
+#[allow(missing_docs)]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct KinfoProc {
+    pub kp_proc: ExternProc,
+    pub kp_eproc: Eproc,
+}
+
+/// Friendly, owned process information obtained via `sysctl(KERN_PROC_PID)`.
+///
+/// Unlike the `proc_pidinfo`-based [`crate::libproc::bsd_info::BSDInfo`], this
+/// works for PID 0 (`kernel_task`) and other processes that `proc_pidinfo`
+/// cannot report.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct KProcInfo {
+    /// Process ID (`kp_proc.p_pid`)
+    pub pid: i32,
+    /// Parent process ID (`kp_eproc.e_ppid`)
+    pub ppid: i32,
+    /// Process group ID (`kp_eproc.e_pgid`)
+    pub pgid: i32,
+    /// Real user ID (`kp_eproc.e_pcred.p_ruid`)
+    pub ruid: u32,
+    /// Nice value (`kp_proc.p_nice`)
+    pub nice: i32,
+    /// Process state / status code (`kp_proc.p_stat`)
+    pub status: i32,
+    /// Scheduling priority (`kp_proc.p_priority`)
+    pub priority: i32,
+    /// Short command name (`kp_proc.p_comm`), NUL-trimmed
+    pub comm: String,
+    /// Process flags (`kp_proc.p_flag`)
+    pub flags: i32,
+}
+
+impl From<&KinfoProc> for KProcInfo {
+    fn from(k: &KinfoProc) -> Self {
+        KProcInfo {
+            pid: k.kp_proc.p_pid,
+            ppid: k.kp_eproc.e_ppid,
+            pgid: k.kp_eproc.e_pgid,
+            ruid: k.kp_eproc.e_pcred.p_ruid,
+            nice: i32::from(k.kp_proc.p_nice),
+            status: i32::from(k.kp_proc.p_stat),
+            priority: i32::from(k.kp_proc.p_priority),
+            comm: c_chars_to_string(&k.kp_proc.p_comm),
+            flags: k.kp_proc.p_flag,
+        }
+    }
+}
+
+/// Convert a NUL-terminated C `char` buffer (`i8`) to a `String` (lossy UTF-8).
+fn c_chars_to_string(buf: &[i8]) -> String {
+    let bytes: Vec<u8> = buf
+        .iter()
+        .take_while(|&&c| c != 0)
+        .map(|&c| c.to_le_bytes()[0])
+        .collect();
+    String::from_utf8_lossy(&bytes).into_owned()
+}

--- a/src/libproc/kinfo.rs
+++ b/src/libproc/kinfo.rs
@@ -220,3 +220,51 @@ fn c_chars_to_string(buf: &[i8]) -> String {
         .collect();
     String::from_utf8_lossy(&bytes).into_owned()
 }
+
+#[cfg(test)]
+mod layout_tests {
+    use super::{Itimerval, Timeval};
+    use std::mem::{align_of, offset_of, size_of};
+
+    // The mirrored `Timeval` / `Itimerval` must match the system's `struct timeval`
+    // / `struct itimerval` exactly, otherwise every field after `p_un` / `p_realtimer`
+    // in `extern_proc` is read at the wrong offset and `sysctl` results are garbage.
+    // `libc` exposes these two types on macOS (unlike `kinfo_proc`), so we use them
+    // as the authoritative reference.
+
+    #[test]
+    fn timeval_matches_libc() {
+        assert_eq!(
+            size_of::<Timeval>(),
+            size_of::<libc::timeval>(),
+            "Timeval size must match libc::timeval"
+        );
+        assert_eq!(
+            align_of::<Timeval>(),
+            align_of::<libc::timeval>(),
+            "Timeval alignment must match libc::timeval"
+        );
+        assert_eq!(offset_of!(Timeval, tv_sec), 0);
+        assert_eq!(
+            offset_of!(Timeval, tv_usec),
+            size_of::<libc::time_t>(),
+            "tv_usec must follow the full-width tv_sec"
+        );
+    }
+
+    #[test]
+    fn itimerval_matches_libc() {
+        assert_eq!(
+            size_of::<Itimerval>(),
+            size_of::<libc::itimerval>(),
+            "Itimerval size must match libc::itimerval"
+        );
+        assert_eq!(align_of::<Itimerval>(), align_of::<libc::itimerval>());
+        assert_eq!(offset_of!(Itimerval, it_interval), 0);
+        assert_eq!(
+            offset_of!(Itimerval, it_value),
+            size_of::<Timeval>(),
+            "it_value must follow it_interval"
+        );
+    }
+}

--- a/src/libproc/mod.rs
+++ b/src/libproc/mod.rs
@@ -31,5 +31,9 @@ pub mod work_queue_info;
 /// Information about Network usage by a process
 pub mod net_info;
 
+#[cfg(any(target_os = "macos", doc))]
+/// Process information via `sysctl(KERN_PROC_PID)` - works for PID 0 (`kernel_task`)
+pub mod kinfo;
+
 mod helpers;
 pub(crate) mod sys;

--- a/src/libproc/proc_pid.rs
+++ b/src/libproc/proc_pid.rs
@@ -26,6 +26,8 @@ use crate::libproc::thread_info::ThreadInfo;
 #[cfg(target_os = "macos")]
 use crate::libproc::work_queue_info::WorkQueueInfo;
 #[cfg(target_os = "macos")]
+use crate::libproc::kinfo::{KProcInfo, KinfoProc};
+#[cfg(target_os = "macos")]
 use crate::osx_libproc_bindings::{
     proc_libversion, proc_name, proc_pidinfo, proc_pidpath, proc_regionfilename,
     PROC_PIDPATHINFO_MAXSIZE,
@@ -559,6 +561,66 @@ pub fn name(pid: i32) -> Result<String, String> {
 ///     }
 /// }
 /// ```
+/// Get the raw macOS `kinfo_proc` structure for `pid` via `sysctl(KERN_PROC_PID)`.
+///
+/// Unlike [`pidinfo`], this works for PID 0 (`kernel_task`) and does not require
+/// root. Returns the raw [`KinfoProc`](crate::libproc::kinfo::KinfoProc); most
+/// callers want the friendly [`kproc_info`] wrapper.
+///
+/// # Errors
+///
+/// Returns an error if `sysctl` fails (e.g. no process with the given `pid`).
+#[cfg(target_os = "macos")]
+pub fn kproc_info_raw(pid: i32) -> Result<KinfoProc, String> {
+    let mut mib: [c_int; 4] = [libc::CTL_KERN, libc::KERN_PROC, libc::KERN_PROC_PID, pid];
+    // KinfoProc is a plain repr(C) struct of scalars/pointers; a zeroed value is a
+    // valid initial state and sysctl overwrites it on success.
+    let mut info = unsafe { mem::zeroed::<KinfoProc>() };
+    let mut size = mem::size_of::<KinfoProc>();
+
+    let ret = unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            4,
+            std::ptr::addr_of_mut!(info).cast::<c_void>(),
+            &raw mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+
+    if ret != 0 {
+        return Err(helpers::get_errno_with_message(ret));
+    }
+    if size == 0 {
+        return Err(format!("No process found with pid {pid}"));
+    }
+    Ok(info)
+}
+
+/// Get process information for `pid` via `sysctl(KERN_PROC_PID)`.
+///
+/// Works for PID 0 (`kernel_task`) and other PIDs where [`pidinfo`] fails, and
+/// does not require root for basic process information. Returns a friendly
+/// [`KProcInfo`](crate::libproc::kinfo::KProcInfo); for the raw structure use
+/// [`kproc_info_raw`].
+///
+/// # Errors
+///
+/// Returns an error if `sysctl` fails (e.g. no process with the given `pid`).
+///
+/// # Example
+/// ```no_run
+/// use libproc::libproc::proc_pid::kproc_info;
+/// if let Ok(info) = kproc_info(0) {
+///     println!("PID 0 is {}", info.comm); // "kernel_task"
+/// }
+/// ```
+#[cfg(target_os = "macos")]
+pub fn kproc_info(pid: i32) -> Result<KProcInfo, String> {
+    kproc_info_raw(pid).map(|raw| KProcInfo::from(&raw))
+}
+
 #[cfg(target_os = "macos")]
 pub fn listpidinfo<T: ListPIDInfo>(pid: i32, max_len: usize) -> Result<Vec<T::Item>, String> {
     let flavor = T::flavor() as i32;

--- a/src/libproc/proc_pid.rs
+++ b/src/libproc/proc_pid.rs
@@ -561,6 +561,35 @@ pub fn name(pid: i32) -> Result<String, String> {
 ///     }
 /// }
 /// ```
+#[cfg(target_os = "macos")]
+pub fn listpidinfo<T: ListPIDInfo>(pid: i32, max_len: usize) -> Result<Vec<T::Item>, String> {
+    let flavor = T::flavor() as i32;
+    // No type `T` will be bigger than `c_int::MAX`!!
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    let buffer_size = size_of::<T::Item>() as c_int * max_len as c_int;
+    let mut buffer = Vec::<T::Item>::with_capacity(max_len);
+    let buffer_ptr = unsafe {
+        buffer.set_len(max_len);
+        buffer.as_mut_ptr().cast::<c_void>()
+    };
+
+    let ret: i32;
+
+    unsafe {
+        ret = proc_pidinfo(pid, flavor, 0, buffer_ptr, buffer_size);
+    };
+
+    if ret <= 0 {
+        Err(helpers::get_errno_with_message(ret))
+    } else {
+        // `ret` must be greater than 0 here, so no sign-loss
+        #[allow(clippy::cast_sign_loss)]
+        let actual_len = ret as usize / size_of::<T::Item>();
+        buffer.truncate(actual_len);
+        Ok(buffer)
+    }
+}
+
 /// Get the raw macOS `kinfo_proc` structure for `pid` via `sysctl(KERN_PROC_PID)`.
 ///
 /// Unlike [`pidinfo`], this works for PID 0 (`kernel_task`) and does not require
@@ -619,35 +648,6 @@ pub fn kproc_info_raw(pid: i32) -> Result<KinfoProc, String> {
 #[cfg(target_os = "macos")]
 pub fn kproc_info(pid: i32) -> Result<KProcInfo, String> {
     kproc_info_raw(pid).map(|raw| KProcInfo::from(&raw))
-}
-
-#[cfg(target_os = "macos")]
-pub fn listpidinfo<T: ListPIDInfo>(pid: i32, max_len: usize) -> Result<Vec<T::Item>, String> {
-    let flavor = T::flavor() as i32;
-    // No type `T` will be bigger than `c_int::MAX`!!
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    let buffer_size = size_of::<T::Item>() as c_int * max_len as c_int;
-    let mut buffer = Vec::<T::Item>::with_capacity(max_len);
-    let buffer_ptr = unsafe {
-        buffer.set_len(max_len);
-        buffer.as_mut_ptr().cast::<c_void>()
-    };
-
-    let ret: i32;
-
-    unsafe {
-        ret = proc_pidinfo(pid, flavor, 0, buffer_ptr, buffer_size);
-    };
-
-    if ret <= 0 {
-        Err(helpers::get_errno_with_message(ret))
-    } else {
-        // `ret` must be greater than 0 here, so no sign-loss
-        #[allow(clippy::cast_sign_loss)]
-        let actual_len = ret as usize / size_of::<T::Item>();
-        buffer.truncate(actual_len);
-        Ok(buffer)
-    }
 }
 
 #[cfg(target_os = "macos")]

--- a/tests/kproc_info.rs
+++ b/tests/kproc_info.rs
@@ -29,6 +29,12 @@ fn kproc_info_self() {
     let info = kproc_info(me).expect("kproc_info for self should succeed");
     assert_eq!(info.pid, me);
     assert!(!info.comm.is_empty(), "self comm should not be empty");
+    // The test process always has a parent, so a correctly-read `eproc` layout
+    // yields a non-zero ppid. (A wrong struct layout typically reads this as 0.)
+    assert!(info.ppid > 0, "self should have a parent, got ppid {}", info.ppid);
+    // Real UID should match what the OS reports for this process.
+    let expected_uid = unsafe { libc::getuid() };
+    assert_eq!(info.ruid, expected_uid, "ruid should match getuid()");
 }
 
 #[test]

--- a/tests/kproc_info.rs
+++ b/tests/kproc_info.rs
@@ -1,0 +1,41 @@
+#![cfg(target_os = "macos")]
+#![allow(clippy::cast_possible_wrap)]
+
+//! Tests for the sysctl-based `kproc_info` API, which works for PID 0
+//! (`kernel_task`) where `proc_pidinfo` fails, and without requiring root.
+
+use libproc::libproc::proc_pid::{kproc_info, kproc_info_raw};
+
+#[test]
+fn kproc_info_pid0_is_kernel_task() {
+    let info = kproc_info(0).expect("kproc_info(0) should succeed for kernel_task");
+    assert_eq!(info.pid, 0);
+    assert!(
+        info.comm.starts_with("kernel_task"),
+        "PID 0 comm should be kernel_task, got {:?}",
+        info.comm
+    );
+}
+
+#[test]
+fn kproc_info_raw_pid0() {
+    let raw = kproc_info_raw(0).expect("raw sysctl for PID 0 should succeed");
+    assert_eq!(raw.kp_proc.p_pid, 0);
+}
+
+#[test]
+fn kproc_info_self() {
+    let me = std::process::id() as i32;
+    let info = kproc_info(me).expect("kproc_info for self should succeed");
+    assert_eq!(info.pid, me);
+    assert!(!info.comm.is_empty(), "self comm should not be empty");
+}
+
+#[test]
+fn kproc_info_nonexistent_pid_errors() {
+    // A very high PID that should not exist.
+    assert!(
+        kproc_info(0x7FFF_FFFE).is_err(),
+        "a non-existent PID should return an error"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #169.

On macOS `proc_pidinfo()` cannot report PID 0 (`kernel_task`), so consumers (e.g. process viewers / htop-like tools) have to hand-roll a `sysctl(KERN_PROC_PID)` fallback. This adds a dedicated macOS API backed by sysctl that works for PID 0 and other PIDs, and does not require root for basic process info.

As discussed in the issue, this is a **separate method** rather than a new `PidInfo`/`PidInfoFlavor` variant, because `kinfo_proc` comes from a different kernel API (`sysctl`) with a completely different struct layout than the `proc_pidinfo` structures.

## API

```rust
/// Friendly, owned wrapper.
#[cfg(target_os = "macos")]
pub fn kproc_info(pid: i32) -> Result<KProcInfo, String>;

/// Raw repr(C) kinfo_proc structure for callers needing full kernel data.
#[cfg(target_os = "macos")]
pub fn kproc_info_raw(pid: i32) -> Result<KinfoProc, String>;
```

`KProcInfo` exposes the fields requested in the issue: `pid`, `ppid`, `pgid`, `ruid`, `nice`, `status`, `priority`, `comm` (`String`), `flags`.

## Notes

- The `kinfo_proc` / `extern_proc` / `eproc` structures are defined in a new `kinfo` module mirroring `<sys/sysctl.h>`, because `libc` does not expose `kinfo_proc` for Apple targets (only for the BSDs). This keeps the sysctl definitions maintained in one place instead of duplicated across every consumer — one of the stated benefits in the issue.
- No new Cargo feature; the API is gated with `#[cfg(target_os = "macos")]` and uses `libc` (already a dependency).

## Tests

New integration tests in `tests/kproc_info.rs` cover PID 0 (`kernel_task`), the current process, the raw accessor, and a non-existent PID. All tests pass, and `clippy` (pedantic, `-D warnings`) and `cargo doc` are clean.